### PR TITLE
increase RAM and CPU limits

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -21,11 +21,11 @@ spec:
             value: "production"
           resources:
             requests:
-              memory: "200Mi"
+              memory: "300Mi"
               cpu: "100m"
             limits:
-              memory: "200Mi"
-              cpu: "500m"
+              memory: "500Mi"
+              cpu: "1000m"
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Avoid OOM errors and allow CPU to burst when required
```
Image ID:       docker.io/zooniverse/markdown-api@sha256:8acff16b2209390c02e2bc6c070d604e27e08d17a76e3ffd9df9d2b96fcad54f
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Mon, 13 Jun 2022 13:00:40 +0100
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Sun, 12 Jun 2022 07:03:01 +0100
      Finished:     Mon, 13 Jun 2022 13:00:39 +0100
    Ready:          True
    Restart Count:  1
    Limits:
      cpu:     500m
      memory:  200Mi
    Requests:
      cpu:      100m
      memory:   200Mi
```